### PR TITLE
Added methods to get values with breakpoints depending on width or height of screen

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,4 +1,4 @@
 object Versions {
     const val JETPACK_COMPOSE = "1.2.0-rc03"
-    const val ANDROID_GRADLE_PLUGIN = "7.3.0-beta05"
+    const val ANDROID_GRADLE_PLUGIN = "7.3.0-rc01"
 }

--- a/utils/src/main/kotlin/com/mirego/compose/utils/Thresholds.kt
+++ b/utils/src/main/kotlin/com/mirego/compose/utils/Thresholds.kt
@@ -2,13 +2,12 @@ package com.mirego.compose.utils
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 
 /**
  * Lets you get values that uses breakpoints on screen width or height
  *
- * val margin = sizeWithWidthThresholds(
+ * val margin = valueWithWidthThresholds(
  *    1000.dp to 128.dp,
  *    600.dp to 64.dp,
  *    0.dp to 12.dp
@@ -16,22 +15,12 @@ import androidx.compose.ui.unit.Dp
  */
 
 @Composable
-fun sizeWithHeightThresholds(vararg thresholds: Pair<Dp, Dp>): Dp = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
+fun <T> valueWithHeightThresholds(vararg thresholds: Pair<Dp, T>): T =
+    valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
 
 @Composable
-fun sizeWithWidthThresholds(vararg thresholds: Pair<Dp, Dp>): Dp = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
-
-@Composable
-fun textStyleWithHeightThresholds(vararg thresholds: Pair<Dp, TextStyle>) = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
-
-@Composable
-fun textStyleWithWidthThresholds(vararg thresholds: Pair<Dp, TextStyle>) = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
-
-@Composable
-fun intWithHeightThresholds(vararg thresholds: Pair<Dp, Int>): Int = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
-
-@Composable
-fun intWithWidthThresholds(vararg thresholds: Pair<Dp, Int>): Int = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
+fun <T> valueWithWidthThresholds(vararg thresholds: Pair<Dp, T>): T =
+    valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
 
 private fun <T> valueWithThresholds(
     comparatorInDp: Int,

--- a/utils/src/main/kotlin/com/mirego/compose/utils/Thresholds.kt
+++ b/utils/src/main/kotlin/com/mirego/compose/utils/Thresholds.kt
@@ -1,0 +1,46 @@
+package com.mirego.compose.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Lets you get values that uses breakpoints on screen width or height
+ *
+ * val margin = sizeWithWidthThresholds(
+ *    1000.dp to 128.dp,
+ *    600.dp to 64.dp,
+ *    0.dp to 12.dp
+ * )
+ */
+
+@Composable
+fun sizeWithHeightThresholds(vararg thresholds: Pair<Dp, Dp>): Dp = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
+
+@Composable
+fun sizeWithWidthThresholds(vararg thresholds: Pair<Dp, Dp>): Dp = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
+
+@Composable
+fun textStyleWithHeightThresholds(vararg thresholds: Pair<Dp, TextStyle>) = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
+
+@Composable
+fun textStyleWithWidthThresholds(vararg thresholds: Pair<Dp, TextStyle>) = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
+
+@Composable
+fun intWithHeightThresholds(vararg thresholds: Pair<Dp, Int>): Int = valueWithThresholds(LocalConfiguration.current.screenHeightDp, *thresholds)
+
+@Composable
+fun intWithWidthThresholds(vararg thresholds: Pair<Dp, Int>): Int = valueWithThresholds(LocalConfiguration.current.screenWidthDp, *thresholds)
+
+private fun <T> valueWithThresholds(
+    comparatorInDp: Int,
+    vararg thresholds: Pair<Dp, T>
+): T {
+    thresholds.forEach {
+        if (comparatorInDp > it.first.value) {
+            return it.second
+        }
+    }
+    throw IllegalStateException("Unmapped value $comparatorInDp")
+}


### PR DESCRIPTION
Sample usage:

```
 val margin = sizeWithWidthThresholds(
    1000.dp to 128.dp,
    600.dp to 64.dp,
    0.dp to 12.dp
 )
```