### PR TITLE
Add preview modifier + versions update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application") version Versions.ANDROID_GRADLE_PLUGIN apply false
     id("com.android.library") version Versions.ANDROID_GRADLE_PLUGIN apply false
-    id("org.jetbrains.kotlin.android") version "1.7.0" apply false
+    id("org.jetbrains.kotlin.android") version Versions.KOTLIN apply false
     id("org.jlleitschuh.gradle.ktlint") version Versions.KTLINT apply false
 
     id("mirego.release") version "2.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,7 @@
 object Versions {
-    const val JETPACK_COMPOSE = "1.2.0-rc03"
-    const val ANDROID_GRADLE_PLUGIN = "7.3.0-rc01"
+    const val ANDROID_GRADLE_PLUGIN = "7.3.1"
     const val KTLINT = "11.0.0"
+    const val KOTLIN = "1.7.20"
+    const val COMPOSE_BOM = "2022.12.00"
+    const val KOTLIN_COMPILER = "1.3.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 14 14:36:24 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         targetCompatibility(JavaVersion.VERSION_11)
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.2.0"
+        kotlinCompilerExtensionVersion = Versions.KOTLIN_COMPILER
     }
     kotlinOptions {
         jvmTarget = "11"
@@ -38,10 +38,14 @@ android {
 }
 
 dependencies {
-    api("androidx.compose.foundation:foundation:${Versions.JETPACK_COMPOSE}")
-    api("androidx.compose.ui:ui:${Versions.JETPACK_COMPOSE}")
-    api("androidx.compose.animation:animation:${Versions.JETPACK_COMPOSE}")
-    api("androidx.compose.material:material:${Versions.JETPACK_COMPOSE}")
+    val composeBom = platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM}")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    api("androidx.compose.foundation:foundation")
+    api("androidx.compose.ui:ui")
+    api("androidx.compose.animation:animation")
+    api("androidx.compose.material:material")
 }
 
 tasks {

--- a/utils/src/main/kotlin/com/mirego/compose/utils/extensions/ModifierExtensions.kt
+++ b/utils/src/main/kotlin/com/mirego/compose/utils/extensions/ModifierExtensions.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalInspectionMode
 import java.util.Calendar
 import kotlin.time.Duration.Companion.seconds
 
@@ -69,4 +70,12 @@ fun Modifier.swallowClicks() =
             interactionSource = remember { MutableInteractionSource() },
             indication = null
         ) {}
+    }
+
+fun Modifier.preview(block: Modifier.() -> Modifier): Modifier =
+    composed {
+        if (LocalInspectionMode.current)
+            block()
+        else
+            this
     }


### PR DESCRIPTION
We add a new `.preview` modifier which can be used to apply modifiers only in LocalInspectionMode.
Example:
```
Modifier
    .fillMaxWidth()
    .preview {
        height(272.dp)
            .background(Color.Magenta)
    }
```

We also update several version and migrate to the Compose BOM dependencies.