### PR TITLE
Lowering min SDK to 21

### DIFF
--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -17,7 +17,7 @@ group = "com.mirego.compose"
 android {
     defaultConfig {
         compileSdk = 33
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
     }
 


### PR DESCRIPTION
The minimum version for using Jetpack Compose is 21, so there is no reason to have a higher minimum than that in the lib. 