### PR TITLE
Fix animated visibility with nullable remembered value not updated with new non-null value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.17.x
+          node-version: 14
 
       - name: Run prettier
         run: npx prettier --check .

--- a/utils/src/main/kotlin/com/mirego/compose/utils/Animations.kt
+++ b/utils/src/main/kotlin/com/mirego/compose/utils/Animations.kt
@@ -60,7 +60,7 @@ fun <T : Any> AnimatedVisibilityWithNullable(
 ) {
     val visible = nullableValue != null
     val remembered = remember(key1 = Unit) { mutableStateOf(nullableValue) }
-    if (remembered.value == null && nullableValue != null) {
+    if ((remembered.value == null && nullableValue != null) || (remembered.value != null && nullableValue != null && remembered.value != nullableValue)) {
         remembered.value = nullableValue
     }
     val stateCleanNeeded = remembered.value != null && nullableValue == null


### PR DESCRIPTION
Avec AnimatedVisibilityWithNullable, il y avait un bug ou lorsque je reçoit séquentiellement un viewmodel non-null A puis un viewmodel non-null B sans recevoir de null entre les 2 c'était le contenu du viewmodel A qui était affiché au lieu du viewmodel B car la remembered value n'était pas updated.

